### PR TITLE
Av1 speed setting

### DIFF
--- a/skoll3webm.lua
+++ b/skoll3webm.lua
@@ -54,7 +54,7 @@ local options = {
 	-- If set, writes the video's filename to the "Title" field on the metadata.
 	write_filename_on_metadata = false,	
 	-- Set the number of encoding threads, for codecs libvpx and libvpx-vp9
-	libvpx_threads = 4,
+	libvpx_threads = 6,
 	additional_flags = "",
 	-- Constant Rate Factor (CRF). The value meaning and limits may change,
 	-- from codec to codec. Set to -1 to disable.
@@ -1012,7 +1012,7 @@ do
     getFlags = function(self)
       return {
         "--ovcopts-add=threads=" .. tostring(options.libvpx_threads),
-	"--ovcopts-add=cpu-used=6",
+        "--ovcopts-add=cpu-used=4",
         "--ovcopts-add=row-mt=1",
         "--ovcopts-add=tiles=2x2"
       }

--- a/skoll3webm.lua
+++ b/skoll3webm.lua
@@ -59,6 +59,7 @@ local options = {
 	-- Constant Rate Factor (CRF). The value meaning and limits may change,
 	-- from codec to codec. Set to -1 to disable.
 	crf = 15,
+	av1_speed = 4,
 	-- Useful for flags that may impact output filesize, such as qmin, qmax etc
 	-- Won't be applied when strict_filesize_constraint is on.
 	non_strict_additional_flags = "",
@@ -1012,7 +1013,6 @@ do
     getFlags = function(self)
       return {
         "--ovcopts-add=threads=" .. tostring(options.libvpx_threads),
-        "--ovcopts-add=cpu-used=4",
         "--ovcopts-add=row-mt=1",
         "--ovcopts-add=tiles=2x2"
       }
@@ -1809,6 +1809,11 @@ encode = function(region, startTime, endTime)
   append(command, {
     "--o=" .. tostring(out_path)
   })
+  if format.videoCodec == "libaom-av1" then
+    append(command, {
+        "--ovcopts-add=cpu-used=" .. options.av1_speed
+    })
+  end
   if options.twopass and format.supportsTwopass and not is_stream then
     local first_pass_cmdline
     do
@@ -2323,6 +2328,31 @@ do
           }
         }
       }
+      local av1SpeedOpts = {
+        possibleValues = {
+          {
+            0
+          },
+          {
+            1
+          },
+          {
+            2
+          },
+          {
+            3
+          },
+          {
+            4
+          },
+          {
+            5
+          },
+          {
+            6
+          }
+        }
+      }
       local formatIds = {
         "webm-vp8",
         "webm-vp9",
@@ -2384,6 +2414,10 @@ do
         {
           "fps",
           Option("list", "FPS", options.fps, fpsOpts)
+        },
+        {
+          "av1_speed",
+          Option("list", "Encoding speed (AV1 only)", options.av1_speed, av1SpeedOpts)
         }
       }
       self.keybinds = {


### PR DESCRIPTION
Speed settings 0-6 added in GUI and in the encoder backend.

Encoding times and file sizes seems to work as expected.